### PR TITLE
fix: redundant categories make Argo keep syncing

### DIFF
--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   group: locmai.dev
   names:
-    categories: []
+    categories:
+      - secretgenerator
     kind: SecretGenerator
     plural: secretgenerators
     shortNames:

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -36,6 +36,7 @@ pub struct DeclaredSecretSpec {
     plural = "secretgenerators",
     namespaced,
     status = "SecretGeneratorStatus",
+    category = "secretgenerator",
     shortname = "sg",
     printcolumn = r#"{"name":"Condition", "type":"string", "description":"condition of the secret-generator", "jsonPath":".status.condition"}, {"name":"Last updated", "type":"date", "description":"last updated timestamp of the secret-generator", "jsonPath":".status.last_updated"}"#
 )]


### PR DESCRIPTION
Address #4 